### PR TITLE
Remove Animation-related stuff from CI envs

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using Test
 
 include("../src/Simulation.jl")
-include("../src/Animation.jl")
+# There are bugs precompiling `CairoMakie.jl` on x86 architecture in CI testing
+haskey(ENV, "CI") || include("../src/Animation.jl")
 include("../src/Routes.jl")
 
 @info "Testing `Simulation` module"


### PR DESCRIPTION
Due to bugs precompiling CairoMakie on x86 architectures, we remove all tests related to the Animation module whenever the environment has the CI key.